### PR TITLE
Fix some inefficiencies in SQLite implementation

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/PrimaryKey.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/PrimaryKey.java
@@ -53,7 +53,7 @@ public class PrimaryKey implements Serializable {
   }
 
   public byte[] asBytesFirstStringIndex() {
-   byte[] arr =  ((String) _values[0]).getBytes(StandardCharsets.UTF_8);
+   byte[] arr = ((String) _values[0]).getBytes(StandardCharsets.UTF_8);
    return arr;
   }
 


### PR DESCRIPTION
This PR includes some improvements on SQLite implementation. I guess they could also be applied to H2, but being heap based, I don't think we care that much about H2.

With this changes results for sqlite went from 20 times slower than rocksdb to 30% faster:

```
Benchmark                                 (_keyCardinality)  (_metadataStoreType)  (_numRows)  (_numRuns)  (_numSegments)  Mode  Cnt    Score   Error  Units
BenchmarkUpsertAddRecord.upsertAddRecord            5000000               ROCKSDB        1000          10              10  avgt    2  237.424          ms/op
BenchmarkUpsertAddRecord.upsertAddRecord            5000000                SQLITE        1000          10              10  avgt    2  179.725          ms/op
```