### PR TITLE
Refactor RealtimeSegmentValidationManager

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -115,6 +115,7 @@ import org.apache.pinot.controller.validation.BrokerResourceValidationManager;
 import org.apache.pinot.controller.validation.DiskUtilizationChecker;
 import org.apache.pinot.controller.validation.OfflineSegmentIntervalChecker;
 import org.apache.pinot.controller.validation.RealtimeSegmentValidationManager;
+import org.apache.pinot.controller.validation.RealtimeConsumptionManager;
 import org.apache.pinot.controller.validation.ResourceUtilizationChecker;
 import org.apache.pinot.controller.validation.ResourceUtilizationManager;
 import org.apache.pinot.controller.validation.StorageQuotaChecker;
@@ -185,6 +186,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   // Can only be constructed after resource manager getting started
   protected OfflineSegmentIntervalChecker _offlineSegmentIntervalChecker;
   protected RealtimeSegmentValidationManager _realtimeSegmentValidationManager;
+  protected RealtimeConsumptionManager _realtimeConsumptionManager;
   protected BrokerResourceValidationManager _brokerResourceValidationManager;
   protected SegmentRelocator _segmentRelocator;
   protected RetentionManager _retentionManager;
@@ -371,6 +373,10 @@ public abstract class BaseControllerStarter implements ServiceStartable {
 
   public RealtimeSegmentValidationManager getRealtimeSegmentValidationManager() {
     return _realtimeSegmentValidationManager;
+  }
+
+  public RealtimeConsumptionManager getRealtimeConsumptionManager() {
+    return _realtimeConsumptionManager;
   }
 
   public BrokerResourceValidationManager getBrokerResourceValidationManager() {
@@ -847,9 +853,11 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     periodicTasks.add(_offlineSegmentIntervalChecker);
     _realtimeSegmentValidationManager =
         new RealtimeSegmentValidationManager(_config, _helixResourceManager, _leadControllerManager,
-            _pinotLLCRealtimeSegmentManager, _validationMetrics, _controllerMetrics, _storageQuotaChecker,
-            _resourceUtilizationManager);
+            _pinotLLCRealtimeSegmentManager, _validationMetrics, _controllerMetrics);
     periodicTasks.add(_realtimeSegmentValidationManager);
+    _realtimeConsumptionManager = new RealtimeConsumptionManager(_config, _helixResourceManager, _leadControllerManager,
+        _pinotLLCRealtimeSegmentManager, _controllerMetrics, _storageQuotaChecker, _resourceUtilizationManager);
+    periodicTasks.add(_realtimeConsumptionManager);
     _brokerResourceValidationManager =
         new BrokerResourceValidationManager(_config, _helixResourceManager, _leadControllerManager, _controllerMetrics);
     periodicTasks.add(_brokerResourceValidationManager);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/Constants.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/Constants.java
@@ -55,6 +55,7 @@ public class Constants {
   public static final String UPSERT_RESOURCE_TAG = "Upsert";
 
   public static final String REALTIME_SEGMENT_VALIDATION_MANAGER = "RealtimeSegmentValidationManager";
+  public static final String REALTIME_CONSUMPTION_MANAGER = "RealtimeConsumptionManager";
 
   public static TableType validateTableType(String tableTypeStr) {
     if (StringUtils.isBlank(tableTypeStr)) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeConsumptionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeConsumptionManager.java
@@ -1,0 +1,128 @@
+package org.apache.pinot.controller.validation;
+
+import com.google.common.base.Preconditions;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.List;
+import java.util.Properties;
+import org.apache.pinot.common.metrics.ControllerGauge;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.LeadControllerManager;
+import org.apache.pinot.controller.api.resources.PauseStatusDetails;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
+import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import org.apache.pinot.spi.config.table.PauseState;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Periodic task to enforce pause state based on resource utilization and storage quota,
+ * and recover realtime segments stuck in ERROR state.
+ */
+public class RealtimeConsumptionManager extends ControllerPeriodicTask<Void> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeConsumptionManager.class);
+
+  private final PinotLLCRealtimeSegmentManager _llcRealtimeSegmentManager;
+  private final StorageQuotaChecker _storageQuotaChecker;
+  private final ResourceUtilizationManager _resourceUtilizationManager;
+  private final boolean _segmentAutoResetOnError;
+
+  public RealtimeConsumptionManager(ControllerConf config, PinotHelixResourceManager pinotHelixResourceManager,
+      LeadControllerManager leadControllerManager, PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
+      ControllerMetrics controllerMetrics, StorageQuotaChecker quotaChecker,
+      ResourceUtilizationManager resourceUtilizationManager) {
+    super("RealtimeConsumptionManager", config.getRealtimeSegmentValidationFrequencyInSeconds(),
+        config.getRealtimeSegmentValidationManagerInitialDelaySeconds(), pinotHelixResourceManager,
+        leadControllerManager, controllerMetrics);
+    _llcRealtimeSegmentManager = llcRealtimeSegmentManager;
+    _storageQuotaChecker = quotaChecker;
+    _resourceUtilizationManager = resourceUtilizationManager;
+    _segmentAutoResetOnError = config.isAutoResetErrorSegmentsOnValidationEnabled();
+    Preconditions.checkState(config.getRealtimeSegmentValidationFrequencyInSeconds() > 0);
+  }
+
+  @Override
+  protected void processTable(String tableNameWithType) {
+    if (!TableNameBuilder.isRealtimeTableResource(tableNameWithType)) {
+      return;
+    }
+
+    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    if (tableConfig == null) {
+      LOGGER.warn("Failed to find table config for table: {}, skipping pause check", tableNameWithType);
+      return;
+    }
+
+    enforcePauseState(tableNameWithType, tableConfig);
+
+    boolean isPauselessConsumptionEnabled =
+        org.apache.pinot.common.utils.PauselessConsumptionUtils.isPauselessEnabled(tableConfig);
+    if (isPauselessConsumptionEnabled) {
+      _llcRealtimeSegmentManager.repairSegmentsInErrorStateForPauselessConsumption(tableConfig);
+    } else if (_segmentAutoResetOnError) {
+      _pinotHelixResourceManager.resetSegments(tableConfig.getTableName(), null, true);
+    }
+  }
+
+  /**
+   * Update the table pause state based on resource and quota validations.
+   */
+  @VisibleForTesting
+  void enforcePauseState(String tableNameWithType, TableConfig tableConfig) {
+    PauseStatusDetails pauseStatus = _llcRealtimeSegmentManager.getPauseStatusDetails(tableNameWithType);
+    boolean isTablePaused = pauseStatus.getPauseFlag();
+    if (isTablePaused && pauseStatus.getReasonCode().equals(PauseState.ReasonCode.ADMINISTRATIVE)) {
+      return;
+    }
+
+    boolean isResourceUtilizationWithinLimits =
+        _resourceUtilizationManager.isResourceUtilizationWithinLimits(tableNameWithType);
+    if (!isResourceUtilizationWithinLimits) {
+      LOGGER.warn("Resource utilization limit exceeded for table: {}", tableNameWithType);
+      _controllerMetrics.setOrUpdateTableGauge(tableNameWithType,
+          ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, 1L);
+      if (!isTablePaused || !pauseStatus.getReasonCode()
+          .equals(PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED)) {
+        _llcRealtimeSegmentManager.pauseConsumption(tableNameWithType,
+            PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, "Resource utilization limit exceeded.");
+      }
+      return;
+    } else if (isTablePaused && pauseStatus.getReasonCode()
+        .equals(PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED)) {
+      _llcRealtimeSegmentManager.updatePauseStateInIdealState(tableNameWithType, false,
+          PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, "Resource utilization within limits");
+      pauseStatus = _llcRealtimeSegmentManager.getPauseStatusDetails(tableNameWithType);
+      isTablePaused = pauseStatus.getPauseFlag();
+    }
+    _controllerMetrics.setOrUpdateTableGauge(tableNameWithType,
+        ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, 0L);
+
+    boolean isQuotaExceeded = _storageQuotaChecker.isTableStorageQuotaExceeded(tableConfig);
+    if (isQuotaExceeded == isTablePaused) {
+      return;
+    }
+    if (isQuotaExceeded) {
+      String storageQuota =
+          tableConfig.getQuotaConfig() != null ? tableConfig.getQuotaConfig().getStorage() : "NA";
+      _llcRealtimeSegmentManager.pauseConsumption(tableNameWithType, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED,
+          "Storage quota of " + storageQuota + " exceeded.");
+    } else {
+      _llcRealtimeSegmentManager.updatePauseStateInIdealState(tableNameWithType, false,
+          PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, "Table storage within quota limits");
+    }
+  }
+
+  @Override
+  protected void nonLeaderCleanup(List<String> tableNamesWithType) {
+    // No-op
+  }
+
+  @Override
+  public void cleanUpTask() {
+    // No-op
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -20,28 +20,25 @@ package org.apache.pinot.controller.validation;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.ValidationMetrics;
-import org.apache.pinot.common.utils.PauselessConsumptionUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.api.resources.PauseStatusDetails;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import org.apache.pinot.controller.validation.RealtimeSegmentValidator;
 import org.apache.pinot.spi.config.table.PauseState;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
@@ -56,33 +53,27 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeSegmentValidationManager.class);
 
   private final PinotLLCRealtimeSegmentManager _llcRealtimeSegmentManager;
+  private final RealtimeSegmentValidator _segmentValidator;
   private final ValidationMetrics _validationMetrics;
   private final ControllerMetrics _controllerMetrics;
-  private final StorageQuotaChecker _storageQuotaChecker;
-  private final ResourceUtilizationManager _resourceUtilizationManager;
-
   private final int _segmentLevelValidationIntervalInSeconds;
   private long _lastSegmentLevelValidationRunTimeMs = 0L;
-  private final boolean _segmentAutoResetOnErrorAtValidation;
 
   public static final String OFFSET_CRITERIA = "offsetCriteria";
   public static final String RUN_SEGMENT_LEVEL_VALIDATION = "runSegmentLevelValidation";
 
   public RealtimeSegmentValidationManager(ControllerConf config, PinotHelixResourceManager pinotHelixResourceManager,
       LeadControllerManager leadControllerManager, PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
-      ValidationMetrics validationMetrics, ControllerMetrics controllerMetrics, StorageQuotaChecker quotaChecker,
-      ResourceUtilizationManager resourceUtilizationManager) {
+      ValidationMetrics validationMetrics, ControllerMetrics controllerMetrics) {
     super("RealtimeSegmentValidationManager", config.getRealtimeSegmentValidationFrequencyInSeconds(),
         config.getRealtimeSegmentValidationManagerInitialDelaySeconds(), pinotHelixResourceManager,
         leadControllerManager, controllerMetrics);
     _llcRealtimeSegmentManager = llcRealtimeSegmentManager;
+    _segmentValidator = new RealtimeSegmentValidator(pinotHelixResourceManager, llcRealtimeSegmentManager,
+        validationMetrics, controllerMetrics);
     _validationMetrics = validationMetrics;
     _controllerMetrics = controllerMetrics;
-    _storageQuotaChecker = quotaChecker;
-    _resourceUtilizationManager = resourceUtilizationManager;
-
     _segmentLevelValidationIntervalInSeconds = config.getSegmentLevelValidationIntervalInSeconds();
-    _segmentAutoResetOnErrorAtValidation = config.isAutoResetErrorSegmentsOnValidationEnabled();
     Preconditions.checkState(_segmentLevelValidationIntervalInSeconds > 0);
   }
 
@@ -116,132 +107,20 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     }
     List<StreamConfig> streamConfigs = IngestionConfigUtils.getStreamConfigs(tableConfig);
 
-    if (shouldEnsureConsuming(tableNameWithType)) {
+    PauseStatusDetails pauseStatus = _llcRealtimeSegmentManager.getPauseStatusDetails(tableNameWithType);
+    if (!pauseStatus.getPauseFlag()) {
       _llcRealtimeSegmentManager.ensureAllPartitionsConsuming(tableConfig, streamConfigs, context._offsetCriteria);
     }
 
     if (context._runSegmentLevelValidation) {
-      runSegmentLevelValidation(tableConfig);
+      _segmentValidator.validate(tableConfig);
     } else {
       LOGGER.info("Skipping segment-level validation for table: {}", tableConfig.getTableName());
     }
 
-    boolean isPauselessConsumptionEnabled = PauselessConsumptionUtils.isPauselessEnabled(tableConfig);
-    if (isPauselessConsumptionEnabled) {
-      // For pauseless tables without dedup or partial upsert, repair segments in error state
-      _llcRealtimeSegmentManager.repairSegmentsInErrorStateForPauselessConsumption(tableConfig);
-    } else if (_segmentAutoResetOnErrorAtValidation) {
-      // Reset for pauseless tables is already handled in repairSegmentsInErrorStateForPauselessConsumption method with
-      // additional checks for pauseless consumption
-      _pinotHelixResourceManager.resetSegments(tableConfig.getTableName(), null, true);
-    }
+    // Error recovery handled by RealtimeConsumptionManager
   }
 
-  /**
-   *
-   * Updates the table paused state based on pause validations (e.g. storage quota being exceeded).
-   * Skips updating the pause state if table is paused by admin.
-   * Returns true if table is not paused
-   */
-  @VisibleForTesting
-  boolean shouldEnsureConsuming(String tableNameWithType) {
-    PauseStatusDetails pauseStatus = _llcRealtimeSegmentManager.getPauseStatusDetails(tableNameWithType);
-    boolean isTablePaused = pauseStatus.getPauseFlag();
-    if (isTablePaused && pauseStatus.getReasonCode().equals(PauseState.ReasonCode.ADMINISTRATIVE)) {
-      return false; // if table is paused by admin, then skip subsequent checks
-    }
-    // Perform resource utilization checks.
-    boolean isResourceUtilizationWithinLimits =
-        _resourceUtilizationManager.isResourceUtilizationWithinLimits(tableNameWithType);
-    if (!isResourceUtilizationWithinLimits) {
-      LOGGER.warn("Resource utilization limit exceeded for table: {}", tableNameWithType);
-      _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED,
-          1L);
-      // update IS when table is not paused or paused with another reason code
-      if (!isTablePaused || !pauseStatus.getReasonCode()
-          .equals(PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED)) {
-        _llcRealtimeSegmentManager.pauseConsumption(tableNameWithType,
-            PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, "Resource utilization limit exceeded.");
-      }
-      return false; // if resource utilization check failed, then skip subsequent checks
-      // within limits and table previously paused by resource utilization --> unpause
-    } else if (isTablePaused && pauseStatus.getReasonCode()
-        .equals(PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED)) {
-      // unset the pause state and allow consuming segment recreation.
-      _llcRealtimeSegmentManager.updatePauseStateInIdealState(tableNameWithType, false,
-          PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, "Resource utilization within limits");
-      pauseStatus = _llcRealtimeSegmentManager.getPauseStatusDetails(tableNameWithType);
-      isTablePaused = pauseStatus.getPauseFlag();
-    }
-    _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED,
-        0L);
-    // Perform storage quota checks.
-    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
-    boolean isQuotaExceeded = _storageQuotaChecker.isTableStorageQuotaExceeded(tableConfig);
-    if (isQuotaExceeded == isTablePaused) {
-      return !isTablePaused;
-    }
-    // if quota breach and pause flag is not in sync, update the IS
-    if (isQuotaExceeded) {
-      String storageQuota = tableConfig.getQuotaConfig() != null ? tableConfig.getQuotaConfig().getStorage() : "NA";
-      // as quota is breached pause the consumption right away
-      _llcRealtimeSegmentManager.pauseConsumption(tableNameWithType, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED,
-          "Storage quota of " + storageQuota + " exceeded.");
-    } else {
-      // as quota limit is being honored, unset the pause state and allow consuming segment recreation.
-      _llcRealtimeSegmentManager.updatePauseStateInIdealState(tableNameWithType, false,
-          PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, "Table storage within quota limits");
-    }
-    return !isQuotaExceeded;
-  }
-
-  private void runSegmentLevelValidation(TableConfig tableConfig) {
-    String realtimeTableName = tableConfig.getTableName();
-
-    List<SegmentZKMetadata> segmentsZKMetadata = _pinotHelixResourceManager.getSegmentsZKMetadata(realtimeTableName);
-
-    // Delete tmp segments
-    if (_llcRealtimeSegmentManager.isTmpSegmentAsyncDeletionEnabled()) {
-      try {
-        long startTimeMs = System.currentTimeMillis();
-        int numDeletedTmpSegments = _llcRealtimeSegmentManager.deleteTmpSegments(realtimeTableName, segmentsZKMetadata);
-        LOGGER.info("Deleted {} tmp segments for table: {} in {}ms", numDeletedTmpSegments, realtimeTableName,
-            System.currentTimeMillis() - startTimeMs);
-        _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.DELETED_TMP_SEGMENT_COUNT,
-            numDeletedTmpSegments);
-      } catch (Exception e) {
-        LOGGER.error("Failed to delete tmp segments for table: {}", realtimeTableName, e);
-      }
-    }
-
-    // Update the total document count gauge
-    _validationMetrics.updateTotalDocumentCountGauge(realtimeTableName, computeTotalDocumentCount(segmentsZKMetadata));
-
-    // Ensures all segments in COMMITTING state are properly tracked in ZooKeeper.
-    // Acts as a recovery mechanism for segments that may have failed to register during start of commit protocol.
-    if (PauselessConsumptionUtils.isPauselessEnabled(tableConfig)) {
-      syncCommittingSegmentsFromMetadata(realtimeTableName, segmentsZKMetadata);
-    }
-
-    // Check missing segments and upload them to the deep store
-    if (_llcRealtimeSegmentManager.isDeepStoreLLCSegmentUploadRetryEnabled()) {
-      _llcRealtimeSegmentManager.uploadToDeepStoreIfMissing(tableConfig, segmentsZKMetadata);
-    }
-  }
-
-  private void syncCommittingSegmentsFromMetadata(String realtimeTableName,
-      List<SegmentZKMetadata> segmentsZKMetadata) {
-    List<String> committingSegments = new ArrayList<>();
-    for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
-      if (CommonConstants.Segment.Realtime.Status.COMMITTING.equals(segmentZKMetadata.getStatus())) {
-        committingSegments.add(segmentZKMetadata.getSegmentName());
-      }
-    }
-    LOGGER.info("Adding committing segments to ZK: {}", committingSegments);
-    if (!_llcRealtimeSegmentManager.syncCommittingSegments(realtimeTableName, committingSegments)) {
-      LOGGER.error("Failed to add committing segments for table: {}", realtimeTableName);
-    }
-  }
 
   private boolean shouldRunSegmentValidation(Properties periodicTaskProperties, long currentTimeMs) {
     boolean runValidation = Optional.ofNullable(
@@ -271,14 +150,6 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     }
   }
 
-  @VisibleForTesting
-  static long computeTotalDocumentCount(List<SegmentZKMetadata> segmentsZKMetadata) {
-    long numTotalDocs = 0;
-    for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
-      numTotalDocs += segmentZKMetadata.getTotalDocs();
-    }
-    return numTotalDocs;
-  }
 
   @Override
   public void cleanUpTask() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidator.java
@@ -1,0 +1,99 @@
+package org.apache.pinot.controller.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ControllerMeter;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.metrics.ValidationMetrics;
+import org.apache.pinot.common.utils.PauselessConsumptionUtils;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class that performs segment level validation for realtime tables.
+ */
+public class RealtimeSegmentValidator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeSegmentValidator.class);
+
+  private final PinotHelixResourceManager _pinotHelixResourceManager;
+  private final PinotLLCRealtimeSegmentManager _llcRealtimeSegmentManager;
+  private final ValidationMetrics _validationMetrics;
+  private final ControllerMetrics _controllerMetrics;
+
+  public RealtimeSegmentValidator(PinotHelixResourceManager pinotHelixResourceManager,
+      PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager, ValidationMetrics validationMetrics,
+      ControllerMetrics controllerMetrics) {
+    _pinotHelixResourceManager = pinotHelixResourceManager;
+    _llcRealtimeSegmentManager = llcRealtimeSegmentManager;
+    _validationMetrics = validationMetrics;
+    _controllerMetrics = controllerMetrics;
+  }
+
+  /**
+   * Run segment level validation for the given realtime table.
+   */
+  public void validate(TableConfig tableConfig) {
+    String realtimeTableName = tableConfig.getTableName();
+    List<SegmentZKMetadata> segmentsZKMetadata =
+        _pinotHelixResourceManager.getSegmentsZKMetadata(realtimeTableName);
+
+    // Delete tmp segments
+    if (_llcRealtimeSegmentManager.isTmpSegmentAsyncDeletionEnabled()) {
+      try {
+        long startTimeMs = System.currentTimeMillis();
+        int numDeletedTmpSegments =
+            _llcRealtimeSegmentManager.deleteTmpSegments(realtimeTableName, segmentsZKMetadata);
+        LOGGER.info("Deleted {} tmp segments for table: {} in {}ms", numDeletedTmpSegments, realtimeTableName,
+            System.currentTimeMillis() - startTimeMs);
+        _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.DELETED_TMP_SEGMENT_COUNT,
+            numDeletedTmpSegments);
+      } catch (Exception e) {
+        LOGGER.error("Failed to delete tmp segments for table: {}", realtimeTableName, e);
+      }
+    }
+
+    // Update the total document count gauge
+    _validationMetrics.updateTotalDocumentCountGauge(realtimeTableName,
+        computeTotalDocumentCount(segmentsZKMetadata));
+
+    // Ensures all segments in COMMITTING state are properly tracked in ZooKeeper.
+    // Acts as a recovery mechanism for segments that may have failed to register during start of commit protocol.
+    if (PauselessConsumptionUtils.isPauselessEnabled(tableConfig)) {
+      syncCommittingSegmentsFromMetadata(realtimeTableName, segmentsZKMetadata);
+    }
+
+    // Check missing segments and upload them to the deep store
+    if (_llcRealtimeSegmentManager.isDeepStoreLLCSegmentUploadRetryEnabled()) {
+      _llcRealtimeSegmentManager.uploadToDeepStoreIfMissing(tableConfig, segmentsZKMetadata);
+    }
+  }
+
+  private void syncCommittingSegmentsFromMetadata(String realtimeTableName,
+      List<SegmentZKMetadata> segmentsZKMetadata) {
+    List<String> committingSegments = new ArrayList<>();
+    for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
+      if (CommonConstants.Segment.Realtime.Status.COMMITTING.equals(segmentZKMetadata.getStatus())) {
+        committingSegments.add(segmentZKMetadata.getSegmentName());
+      }
+    }
+    LOGGER.info("Adding committing segments to ZK: {}", committingSegments);
+    if (!_llcRealtimeSegmentManager.syncCommittingSegments(realtimeTableName, committingSegments)) {
+      LOGGER.error("Failed to add committing segments for table: {}", realtimeTableName);
+    }
+  }
+
+  @VisibleForTesting
+  public static long computeTotalDocumentCount(List<SegmentZKMetadata> segmentsZKMetadata) {
+    long numTotalDocs = 0;
+    for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadata) {
+      numTotalDocs += segmentZKMetadata.getTotalDocs();
+    }
+    return numTotalDocs;
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/ValidationManagerTest.java
@@ -117,7 +117,7 @@ public class ValidationManagerTest {
     segmentsZKMetadata.add(SegmentMetadataMockUtils.mockSegmentZKMetadata(segmentName5, 10));
     segmentsZKMetadata.add(SegmentMetadataMockUtils.mockSegmentZKMetadata(segmentName6, 5));
     segmentsZKMetadata.add(SegmentMetadataMockUtils.mockSegmentZKMetadata(TEST_SEGMENT_NAME, 15));
-    assertEquals(RealtimeSegmentValidationManager.computeTotalDocumentCount(segmentsZKMetadata), 30);
+    assertEquals(RealtimeSegmentValidator.computeTotalDocumentCount(segmentsZKMetadata), 30);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- move pause/quota enforcement and ERROR recovery into a new periodic task
- create `RealtimeConsumptionManager` for pause checks and segment reset
- update `RealtimeSegmentValidationManager` to only validate segments
- wire new task in `BaseControllerStarter`
- update related tests

## Testing
- `mvn -q -pl pinot-controller -am -DskipTests install` *(fails: repository requires network access)*