### PR TITLE
Add interactive Pinot CLI tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,11 @@ cscope.*
 maven-eclipse.xml
 target/
 /examples/
+pinot-cli/node_modules/
 /logs/
 bin/
 */bin/
+!pinot-cli/bin/
 .idea
 .vscode
 *.iml

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
   - [Apache Pinot YouTube Channel](#apache-pinot-youtube-channel)
   - [Building Pinot](#building-pinot)
   - [Deploying Pinot to Kubernetes](#deploying-pinot-to-kubernetes)
+  - [Pinot CLI](#pinot-cli)
   - [Join the Community](#join-the-community)
   - [Documentation](#documentation)
   - [License](#license)
@@ -141,6 +142,30 @@ More detailed instructions can be found at [Quick Demo](https://docs.pinot.apach
 
 ## Deploying Pinot to Kubernetes
 Please refer to [Running Pinot on Kubernetes](https://docs.pinot.apache.org/basics/getting-started/kubernetes-quickstart) in our project documentation. Pinot also provides Kubernetes integrations with the interactive query engine, [Trino](https://docs.pinot.apache.org/integrations/trino) [Presto](https://docs.pinot.apache.org/integrations/presto), and the data visualization tool, [Apache Superset](helm/superset.yaml).
+
+## Pinot CLI
+Pinot provides a simple command line interface built on Node.js. The CLI lives in the `pinot-cli` directory. Install its dependencies and initialize the connection to your Pinot controller:
+
+```bash
+cd pinot-cli
+npm install
+node bin/pinot-cli.js init
+```
+
+The init command stores the controller URL and optional auth token in `~/.pinot-cli.json`. Running `pinot-cli` with no arguments launches an interactive menu offering the following tools:
+
+1. Init config
+2. Health check
+3. List tables
+4. Describe table
+5. Create table
+6. Delete table
+7. List schemas
+8. Add schema
+9. Run query
+10. List segments
+11. Reload table
+12. Exit
 
 ## Join the Community
  - Ask questions on [Apache Pinot Slack](https://join.slack.com/t/apache-pinot/shared_invite/zt-5z7pav2f-yYtjZdVA~EDmrGkho87Vzw)

--- a/pinot-cli/bin/pinot-cli.js
+++ b/pinot-cli/bin/pinot-cli.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import React from 'react';
+import { render } from 'ink';
+import Menu from '../src/Menu.js';
+import { initConfig } from '../src/init.js';
+
+const program = new Command();
+
+program
+  .name('pinot-cli')
+  .description('Interactive CLI for Apache Pinot')
+  .version('0.1.0');
+
+program
+  .command('init')
+  .description('Configure base URL and auth token')
+  .action(async () => {
+    await initConfig();
+  });
+
+program
+  .command('menu')
+  .description('Start interactive menu')
+  .action(() => {
+    render(React.createElement(Menu));
+  });
+
+program.parse(process.argv);
+
+if (process.argv.length <= 2) {
+  render(React.createElement(Menu));
+}

--- a/pinot-cli/package.json
+++ b/pinot-cli/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "pinot-cli",
+  "version": "0.1.0",
+  "description": "Interactive CLI for Apache Pinot",
+  "bin": {
+    "pinot-cli": "bin/pinot-cli.js"
+  },
+  "type": "module",
+  "scripts": {
+    "start": "node bin/pinot-cli.js"
+  },
+  "dependencies": {
+    "commander": "^11.0.0",
+    "ink": "^4.2.0",
+    "node-fetch": "^3.3.2",
+    "react": "^18.2.0"
+  }
+}

--- a/pinot-cli/src/Menu.js
+++ b/pinot-cli/src/Menu.js
@@ -1,0 +1,44 @@
+import React, {useState} from 'react';
+import {Box, Text, useInput, useApp} from 'ink';
+import * as actions from './actions.js';
+
+const Menu = () => {
+  const {exit} = useApp();
+  const [index, setIndex] = useState(0);
+  const options = [
+    {label: 'Init config', action: actions.actionInit},
+    {label: 'Health check', action: actions.healthCheck},
+    {label: 'List tables', action: actions.listTables},
+    {label: 'Describe table', action: actions.describeTable},
+    {label: 'Create table', action: actions.createTable},
+    {label: 'Delete table', action: actions.deleteTable},
+    {label: 'List schemas', action: actions.listSchemas},
+    {label: 'Add schema', action: actions.addSchema},
+    {label: 'Run query', action: actions.runQuery},
+    {label: 'List segments', action: actions.listSegments},
+    {label: 'Reload table', action: actions.reloadTable},
+    {label: 'Exit', action: () => exit()}
+  ];
+
+  useInput(async (input, key) => {
+    if (key.downArrow) {
+      setIndex((index + 1) % options.length);
+    } else if (key.upArrow) {
+      setIndex((index - 1 + options.length) % options.length);
+    } else if (key.return) {
+      await options[index].action();
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      {options.map((option, i) => (
+        <Text key={option.label} color={index === i ? 'green' : undefined}>
+          {index === i ? '❯ ' : '  '}{option.label}
+        </Text>
+      ))}
+    </Box>
+  );
+};
+
+export default Menu;

--- a/pinot-cli/src/actions.js
+++ b/pinot-cli/src/actions.js
@@ -1,0 +1,76 @@
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { request } from './api.js';
+import { initConfig } from './init.js';
+
+async function prompt(question) {
+  const rl = readline.createInterface({ input, output });
+  const answer = await rl.question(question);
+  rl.close();
+  return answer;
+}
+
+export async function actionInit() {
+  await initConfig();
+}
+
+export async function healthCheck() {
+  const text = await request('GET', '/health');
+  console.log(text);
+}
+
+export async function listTables() {
+  const text = await request('GET', '/tables');
+  console.log(text);
+}
+
+export async function describeTable() {
+  const name = await prompt('Table name: ');
+  const text = await request('GET', `/tables/${name}`);
+  console.log(text);
+}
+
+export async function createTable() {
+  const path = await prompt('Path to table config JSON: ');
+  const fs = await import('fs');
+  const body = JSON.parse(fs.readFileSync(path, 'utf8'));
+  const text = await request('POST', '/tables', body);
+  console.log(text);
+}
+
+export async function deleteTable() {
+  const name = await prompt('Table name: ');
+  const text = await request('DELETE', `/tables/${name}`);
+  console.log(text);
+}
+
+export async function listSchemas() {
+  const text = await request('GET', '/schemas');
+  console.log(text);
+}
+
+export async function addSchema() {
+  const path = await prompt('Path to schema JSON: ');
+  const fs = await import('fs');
+  const body = JSON.parse(fs.readFileSync(path, 'utf8'));
+  const text = await request('POST', '/schemas', body);
+  console.log(text);
+}
+
+export async function runQuery() {
+  const sql = await prompt('SQL query: ');
+  const text = await request('POST', '/query/sql', { sql });
+  console.log(text);
+}
+
+export async function listSegments() {
+  const name = await prompt('Table name: ');
+  const text = await request('GET', `/tables/${name}/segments`);
+  console.log(text);
+}
+
+export async function reloadTable() {
+  const name = await prompt('Table name: ');
+  const text = await request('POST', `/tables/${name}/reload`);
+  console.log(text);
+}

--- a/pinot-cli/src/api.js
+++ b/pinot-cli/src/api.js
@@ -1,0 +1,21 @@
+import fetch from 'node-fetch';
+import { loadConfig } from './config.js';
+
+function headers(config) {
+  const h = { 'Content-Type': 'application/json' };
+  if (config.token) {
+    h['Authorization'] = `Bearer ${config.token}`;
+  }
+  return h;
+}
+
+export async function request(method, path, body) {
+  const config = loadConfig();
+  const res = await fetch(`${config.baseUrl}${path}`, {
+    method,
+    headers: headers(config),
+    body: body ? JSON.stringify(body) : undefined
+  });
+  const text = await res.text();
+  return text;
+}

--- a/pinot-cli/src/config.js
+++ b/pinot-cli/src/config.js
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export const configPath = path.join(os.homedir(), '.pinot-cli.json');
+
+export function loadConfig() {
+  try {
+    return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  } catch {
+    return { baseUrl: 'http://localhost:9000', token: '' };
+  }
+}
+
+export function saveConfig(config) {
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+}

--- a/pinot-cli/src/init.js
+++ b/pinot-cli/src/init.js
@@ -1,0 +1,17 @@
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { loadConfig, saveConfig, configPath } from './config.js';
+
+export async function initConfig() {
+  const rl = readline.createInterface({ input, output });
+  const current = loadConfig();
+  const url = await rl.question(`Controller URL [${current.baseUrl}]: `);
+  const token = await rl.question(`Auth token (leave empty if none): `);
+  rl.close();
+  const config = {
+    baseUrl: url || current.baseUrl,
+    token: token || ''
+  };
+  saveConfig(config);
+  console.log(`Configuration saved to ${configPath}`);
+}


### PR DESCRIPTION
## Summary
- extend pinot-cli package with config and API helpers
- add `init` command and 10 interactive tools in Menu
- document CLI initialization and options in README

## Testing
- `node -v`
- `mvn -q -N validate` *(fails: could not resolve dependencies)*
- `npm install` *(fails to fetch packages due to network)*