### PR TITLE
Add iterator age based ingestion lag for Kinesis

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerPartitionLag.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerPartitionLag.java
@@ -23,9 +23,16 @@ import org.apache.pinot.spi.stream.PartitionLagState;
 
 public class KinesisConsumerPartitionLag extends PartitionLagState {
   private final String _availabilityLagMs;
+  private final String _iteratorAgeMs;
 
-  public KinesisConsumerPartitionLag(String availabilityLagMs) {
+  public KinesisConsumerPartitionLag(String availabilityLagMs, String iteratorAgeMs) {
     _availabilityLagMs = availabilityLagMs;
+    _iteratorAgeMs = iteratorAgeMs;
+  }
+
+  @Override
+  public String getRecordsLag() {
+    return _iteratorAgeMs;
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMessageMetadata.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMessageMetadata.java
@@ -28,6 +28,7 @@ import org.apache.pinot.spi.stream.StreamMessageMetadata;
 public class KinesisStreamMessageMetadata extends StreamMessageMetadata {
   public static final String APPRX_ARRIVAL_TIMESTAMP_KEY = "apprxArrivalTimestamp";
   public static final String SEQUENCE_NUMBER_KEY = "sequenceNumber";
+  public static final String ITERATOR_AGE_MS_KEY = "iteratorAgeMs";
 
   @Deprecated
   public KinesisStreamMessageMetadata(long recordIngestionTimeMs, @Nullable GenericRow headers) {


### PR DESCRIPTION
## Summary
- provide iterator-age based records lag for Kinesis
- expose iterator age and availability lag via KinesisConsumerPartitionLag

## Testing
- `mvn -q -pl pinot-plugins/pinot-stream-ingestion/pinot-kinesis -am -DskipTests install` *(fails: Could not resolve artifacts)*
