### PR TITLE
Add table duplication feature in Pinot UI

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -431,6 +431,21 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
     }
   };
 
+  const handleDuplicateTable = async () => {
+    const newName = window.prompt('New table name', tableName);
+    if (!newName) {
+      return;
+    }
+
+    const result = await PinotMethodUtils.duplicateTableOp(tableName, newName);
+    if ((result as any).status) {
+      dispatch({ type: 'success', message: (result as any).status, show: true });
+      fetchTableData();
+    } else {
+      dispatch({ type: 'error', message: (result as any).error, show: true });
+    }
+  };
+
   const handleReloadSegments = () => {
     setDialogDetails({
       title: 'Reload all segments',
@@ -657,6 +672,13 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
                 enableTooltip={true}
               >
                 Delete Table
+              </CustomButton>
+              <CustomButton
+                onClick={handleDuplicateTable}
+                tooltipTitle="Duplicate Table"
+                enableTooltip={true}
+              >
+                Duplicate Table
               </CustomButton>
               <CustomButton
                 onClick={()=>{

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -1061,6 +1061,46 @@ const repairTableOp = (tableName, tableType) => {
     return response.data;
   });
 };
+
+// Duplicate a table by fetching the table and schema config, renaming them and
+// saving as new resources
+const duplicateTableOp = async (tableName: string, newTableName: string) => {
+  try {
+    const [tableDetails, schemaDetails] = await Promise.all([
+      getTableDetails(tableName),
+      getTableSchemaData(tableName)
+    ]);
+
+    if ((tableDetails as any).error) {
+      return { error: (tableDetails as any).error };
+    }
+    if ((schemaDetails as any).error) {
+      return { error: (schemaDetails as any).error };
+    }
+
+    const tableConfig = (tableDetails as any).OFFLINE || (tableDetails as any).REALTIME || tableDetails;
+
+    const newTableConfig = {
+      ...tableConfig,
+      tableName: newTableName,
+      segmentsConfig: {
+        ...tableConfig.segmentsConfig,
+        schemaName: newTableName
+      }
+    };
+
+    const newSchemaConfig = { ...(schemaDetails as any), schemaName: newTableName };
+
+    const schemaResp = await saveSchemaAction(JSON.stringify(newSchemaConfig));
+    if ((schemaResp as any).error) {
+      return { error: (schemaResp as any).error };
+    }
+
+    return await saveTableAction(JSON.stringify(newTableConfig));
+  } catch (error) {
+    return { error: error.toString() };
+  }
+};
 const validateSchemaAction = (schemaObj) => {
   return validateSchema(schemaObj).then((response)=>{
     return response.data;
@@ -1392,6 +1432,7 @@ export default {
   rebalanceServersForTableOp,
   rebalanceBrokersForTableOp,
   repairTableOp,
+  duplicateTableOp,
   validateSchemaAction,
   validateTableAction,
   saveSchemaAction,


### PR DESCRIPTION
## Summary
- allow duplicating tables through UI
- duplicate table and schema on button click

## Testing
- `mvn -q -pl pinot-controller -am -DskipTests package` *(fails: repo.maven.apache.org: Name or service not known)*