### PR TITLE
Throttle transform exception logs

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -115,6 +115,7 @@ import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.apache.pinot.spi.utils.retry.RetryPolicy;
+import com.google.common.util.concurrent.RateLimiter;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
@@ -331,6 +332,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private final SegmentCommitterFactory _segmentCommitterFactory;
   private final ConsumptionRateLimiter _partitionRateLimiter;
   private final ConsumptionRateLimiter _serverRateLimiter;
+  private final RateLimiter _transformErrorLogRateLimiter = RateLimiter.create(1.0);
 
   private final StreamPartitionMsgOffset _latestStreamOffsetAtStartupTime;
   private final CompletionMode _segmentCompletionMode;
@@ -651,7 +653,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           reusedResult.getTransformedRows().clear();
           String errorMessage = "Caught exception while transforming the record at offset: " + offset + " , row: "
               + decodedRow.getResult();
-          _segmentLogger.error(errorMessage, e);
+          if (_transformErrorLogRateLimiter.tryAcquire()) {
+            _segmentLogger.error(errorMessage, e);
+          }
           _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
         }
         if (reusedResult.getSkippedRowCount() > 0) {


### PR DESCRIPTION
## Summary
- rate limit segment transform error logs to once per second

## Testing
- `mvn -q -pl pinot-core -am -DskipTests package` *(failed: plugin com.gradle:develocity-maven-extension could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_683f4823a2688323b710ea07f8df7b8d