### PR TITLE
Add dry-run support for deleteSegmentsFromSequenceNum

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DeleteSegmentsFromSequenceNumResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DeleteSegmentsFromSequenceNumResponse.java
@@ -1,0 +1,32 @@
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Response object for deleteSegmentsFromSequenceNum API.
+ */
+public class DeleteSegmentsFromSequenceNumResponse {
+  private final List<String> _segments;
+  private final boolean _dryRun;
+
+  @JsonCreator
+  public DeleteSegmentsFromSequenceNumResponse(
+      @JsonProperty("segments") List<String> segments,
+      @JsonProperty("dryRun") boolean dryRun) {
+    _segments = segments;
+    _dryRun = dryRun;
+  }
+
+  @JsonProperty("segments")
+  public List<String> getSegments() {
+    return _segments;
+  }
+
+  @JsonProperty("dryRun")
+  public boolean isDryRun() {
+    return _dryRun;
+  }
+}
+


### PR DESCRIPTION
## Summary
- return deleted segments from `deleteSegmentsFromSequenceNum` API
- add a new `dryRun` option
- provide response object `DeleteSegmentsFromSequenceNumResponse`
- test dry-run behaviour

## Testing
- `mvn -q -pl pinot-controller -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683fe5056bd48323bb22b0d942a862ae