### PR TITLE
Handle invalid geometry in H3 index creation

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -108,6 +108,9 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   NO_TABLE_ACCESS("tables", true),
   INDEXING_FAILURES("attributeValues", true),
 
+  /** Number of rows skipped due to null or invalid geometry */
+  NULL_GEOMETRY_ROWS("rows", true),
+
   READINESS_CHECK_OK_CALLS("readinessCheck", true),
   READINESS_CHECK_BAD_CALLS("readinessCheck", true),
   QUERIES_KILLED("query", true),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.TreeMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.utils.GeometrySerializer;
+import org.apache.pinot.common.metrics.ServerMeter;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.utils.H3Utils;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.creator.GeoSpatialIndexCreator;
@@ -116,6 +118,10 @@ public abstract class BaseH3IndexCreator implements GeoSpatialIndexCreator {
   public void add(Geometry geometry)
       throws IOException {
     if (geometry == null) {
+      ServerMetrics metrics = ServerMetrics.get();
+      if (metrics != null) {
+        metrics.addMeteredGlobalValue(ServerMeter.NULL_GEOMETRY_ROWS, 1);
+      }
       _nextDocId++;
       return;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
@@ -104,12 +104,21 @@ public abstract class BaseH3IndexCreator implements GeoSpatialIndexCreator {
 
   @Override
   public Geometry deserialize(byte[] bytes) {
-    return GeometrySerializer.deserialize(bytes);
+    try {
+      return GeometrySerializer.deserialize(bytes);
+    } catch (Exception e) {
+      // For invalid serialized geometry, return null so that the doc can be skipped
+      return null;
+    }
   }
 
   @Override
   public void add(Geometry geometry)
       throws IOException {
+    if (geometry == null) {
+      _nextDocId++;
+      return;
+    }
     Preconditions.checkState(geometry instanceof Point, "H3 index can only be applied to Point, got: %s",
         geometry.getGeometryType());
     Coordinate coordinate = geometry.getCoordinate();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
@@ -123,6 +123,34 @@ public class H3IndexTest implements PinotBuffersAfterMethodCheckRule {
     }
   }
 
+  @Test
+  public void testSkipNullOrInvalidGeometry()
+      throws Exception {
+    String columnName = "skipInvalid";
+    int res = 5;
+    H3IndexResolution resolution = new H3IndexResolution(Collections.singletonList(res));
+
+    try (GeoSpatialIndexCreator creator = new OnHeapH3IndexCreator(TEMP_DIR, columnName, resolution)) {
+      Point point = GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(10, 20));
+      creator.add(point);
+
+      // Invalid serialized bytes should be skipped without throwing exception
+      creator.add(new byte[]{1, 2, 3}, -1);
+
+      // Explicit null geometry should also be skipped
+      creator.add((Geometry) null);
+
+      creator.seal();
+    }
+
+    File indexFile = new File(TEMP_DIR, columnName + V1Constants.Indexes.H3_INDEX_FILE_EXTENSION);
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(indexFile);
+        H3IndexReader reader = new ImmutableH3IndexReader(buffer)) {
+      long h3Id = H3Utils.H3_CORE.latLngToCell(20, 10, res);
+      Assert.assertEquals(reader.getDocIds(h3Id).getCardinality(), 1);
+    }
+  }
+
   public static class ConfTest extends AbstractSerdeIndexContract {
 
     protected void assertEquals(H3IndexConfig expected) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/GeoSpatialIndexCreator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/GeoSpatialIndexCreator.java
@@ -35,7 +35,14 @@ public interface GeoSpatialIndexCreator extends IndexCreator {
   @Override
   default void add(@Nonnull Object value, int dictId)
       throws IOException {
-    add(deserialize((byte[]) value));
+    Geometry geometry = null;
+    try {
+      geometry = deserialize((byte[]) value);
+    } catch (Exception e) {
+      // Swallow the exception and treat the geometry as null
+      geometry = null;
+    }
+    add(geometry);
   }
 
   @Override


### PR DESCRIPTION
## Summary
- prevent exceptions during geospatial deserialisation
- skip documents with invalid or null geometry when building H3 index

## Testing
- `mvn -q -pl pinot-segment-local,pinot-segment-spi -am test` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68404a680f5883238f78cfafbc90442c