### PR TITLE
Fix misleading start offset in data loss log

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1072,7 +1072,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     if (messageBatch.hasDataLoss()) {
       _serverMetrics.setValueOfTableGauge(_tableStreamName, ServerGauge.STREAM_DATA_LOSS, 1L);
       String message = "Message loss detected in stream partition: " + _partitionGroupId + " for table: "
-          + _tableNameWithType + " startOffset: " + _startOffset + " batchFirstOffset: "
+          + _tableNameWithType + " startOffset: " + _currentOffset + " batchFirstOffset: "
           + messageBatch.getFirstMessageOffset();
       _segmentLogger.error(message);
       _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), message, null));


### PR DESCRIPTION
## Summary
- log the actual offset used when checking for data loss instead of the segment start offset

## Testing
- `.github/workflows/scripts/.pinot_linter.sh` *(fails: Failed to read artifact descriptor for com.gradle:develocity-maven-extension)*

------
https://chatgpt.com/codex/tasks/task_e_6841b9cd59c88323bce68259ca9be4a0