### PR TITLE
Add metric for config and schema updates

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -70,6 +70,10 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   IDEAL_STATE_UPDATE_RETRY("IdealStateUpdateRetry", false),
   IDEAL_STATE_UPDATE_SUCCESS("IdealStateUpdateSuccess", false),
   SEGMENT_SIZE_AUTO_REDUCTION("SegmentSizeAutoReduction", false),
+  /** Metric counting successful table config updates */
+  TABLE_CONFIG_UPDATED("tableConfigUpdated", true),
+  /** Metric counting successful schema updates */
+  SCHEMA_UPDATED("schemaUpdated", true),
   // Total Bytes read from deep store
   DEEP_STORE_READ_BYTES_COMPLETED("deepStoreReadBytesCompleted", true),
   // Total Bytes written to deep store

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -118,6 +118,7 @@ import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataUtils;
 import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.minion.MinionTaskMetadataUtils;
 import org.apache.pinot.common.restlet.resources.EndReplaceSegmentsRequest;
 import org.apache.pinot.common.restlet.resources.RevertReplaceSegmentsRequest;
@@ -1618,6 +1619,9 @@ public class PinotHelixResourceManager {
       }
     }
     ZKMetadataProvider.setSchema(_propertyStore, schema);
+    if (_controllerMetrics != null) {
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.SCHEMA_UPDATED, 1L);
+    }
     LOGGER.info("Updated schema: {}", schemaName);
   }
 
@@ -2220,6 +2224,9 @@ public class PinotHelixResourceManager {
 
     // Send update query quota message if quota is specified
     sendTableConfigRefreshMessage(tableNameWithType);
+    if (_controllerMetrics != null) {
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.TABLE_CONFIG_UPDATED, 1L);
+    }
   }
 
   public void deleteUser(String username) {


### PR DESCRIPTION
## Summary
- add controller meters for table config updates and schema updates separately
- increment the new metrics when schema or table configs change

## Testing
- `mvn test -pl pinot-common,pinot-controller -am -DskipITs` *(fails: Plugin com.gradle:develocity-maven-extension:2.0.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6846e28ebbec8323ab1dc41c764c9ae2