### PR TITLE
Validate enforceConsumptionInOrder for partial upsert and dedup tables

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -781,6 +781,15 @@ public final class TableConfigUtils {
 
     boolean isUpsertEnabled = tableConfig.getUpsertMode() != UpsertConfig.Mode.NONE;
     boolean isDedupEnabled = tableConfig.getDedupConfig() != null && tableConfig.getDedupConfig().isDedupEnabled();
+    boolean isPartialUpsertEnabled = tableConfig.getUpsertMode() == UpsertConfig.Mode.PARTIAL;
+
+    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
+    StreamIngestionConfig streamIngestionConfig = ingestionConfig != null ? ingestionConfig.getStreamIngestionConfig()
+        : null;
+    if ((isPartialUpsertEnabled || isDedupEnabled) && streamIngestionConfig != null) {
+      Preconditions.checkState(streamIngestionConfig.isEnforceConsumptionInOrder(),
+          "enforceConsumptionInOrder must be enabled for partial upsert or dedup table");
+    }
 
     // check both upsert and dedup are not enabled simultaneously
     Preconditions.checkState(!(isUpsertEnabled && isDedupEnabled),

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -2705,6 +2705,45 @@ public class TableConfigUtilsTest {
   }
 
   @Test
+  public void testValidateEnforceConsumptionInOrderForPartialUpsertAndDedup() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .setPrimaryKeyColumns(Lists.newArrayList("myPkCol"))
+        .addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("myPkCol", FieldSpec.DataType.STRING)
+        .build();
+    Map<String, String> streamConfigs = getStreamConfigs();
+
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(Collections.singletonList(streamConfigs));
+    streamIngestionConfig.setEnforceConsumptionInOrder(false);
+    ingestionConfig.setStreamIngestionConfig(streamIngestionConfig);
+
+    TableConfig partialUpsertTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.PARTIAL))
+        .setRoutingConfig(
+            new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false))
+        .setIngestionConfig(ingestionConfig)
+        .build();
+    IllegalStateException e = expectThrows(IllegalStateException.class,
+        () -> TableConfigUtils.validateUpsertAndDedupConfig(partialUpsertTableConfig, schema));
+    assertEquals(e.getMessage(), "enforceConsumptionInOrder must be enabled for partial upsert or dedup table");
+
+    TableConfig dedupTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setDedupConfig(new DedupConfig(true, null))
+        .setRoutingConfig(
+            new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false))
+        .setIngestionConfig(ingestionConfig)
+        .build();
+    e = expectThrows(IllegalStateException.class,
+        () -> TableConfigUtils.validateUpsertAndDedupConfig(dedupTableConfig, schema));
+    assertEquals(e.getMessage(), "enforceConsumptionInOrder must be enabled for partial upsert or dedup table");
+
+    streamIngestionConfig.setEnforceConsumptionInOrder(true);
+    TableConfigUtils.validateUpsertAndDedupConfig(partialUpsertTableConfig, schema);
+    TableConfigUtils.validateUpsertAndDedupConfig(dedupTableConfig, schema);
+  }
+
+  @Test
   public void testValidatePartialUpsertConfig() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
         .addSingleValueDimension("myCol1", FieldSpec.DataType.LONG)


### PR DESCRIPTION
### Motivation
- Prevent creating or updating realtime tables with partial upsert or dedup semantics when stream consumption order enforcement is disabled, because these table types require ordered segment consumption for correctness.

### Description
- Add a validation in `TableConfigUtils.validateUpsertAndDedupConfig(...)` that checks `ingestionConfig.streamIngestionConfig.enforceConsumptionInOrder` and throws `IllegalStateException` if it is explicitly `false` for partial upsert or dedup realtime tables.
- Detect partial upsert via `tableConfig.getUpsertMode() == UpsertConfig.Mode.PARTIAL` and dedup via `tableConfig.getDedupConfig().isDedupEnabled()` and perform the check when a `StreamIngestionConfig` is present.
- Add unit test `testValidateEnforceConsumptionInOrderForPartialUpsertAndDedup` in `TableConfigUtilsTest` which asserts validation fails when `enforceConsumptionInOrder=false` for both partial-upsert and dedup, and succeeds when set to `true`.

### Testing
- Attempted to run the focused unit test via Maven: `mvn -pl pinot-segment-local -Dtest=TableConfigUtilsTest#testValidateEnforceConsumptionInOrderForPartialUpsertAndDedup test`, which failed in this environment due to missing pre-built snapshot dependencies and wrapper files.
- Ran `mvn -pl pinot-segment-local -am -Dtest=TableConfigUtilsTest#testValidateEnforceConsumptionInOrderForPartialUpsertAndDedup -Dsurefire.failIfNoSpecifiedTests=false test`, which progressed through the reactor but did not execute the target test due to upstream module test-selection and reactor behavior (build failed before reaching the module tests).
- Changes were committed after local edit and unit test addition, but full CI verification is recommended (run standard Maven build `./mvnw clean install` or `./mvnw -pl pinot-segment-local -am test` in a developer environment with project snapshots available) to validate end-to-end compilation and test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8f14daa8c8324a2dd9bf7bed09beb)